### PR TITLE
Improve linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Given the following source code `example.go`:
 parameter-swap will report the following:
 
 ```console
-$t parameter-swap ./...
-.../example.go:9:13: argument two in position 0 matches parameter in position 1
-.../example.go:9:13: argument one in position 1 matches parameter in position 0
+$ parameter-swap ./...
+.../example.go:9:6: foo argument two in position 0 matches parameter in position 1
+.../example.go:9:11: foo argument one in position 1 matches parameter in position 0
 exit status 3
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ parameter-swap will report the following:
 
 ```console
 $ parameter-swap ./...
-.../example.go:9:6: foo argument two in position 0 matches parameter in position 1
-.../example.go:9:11: foo argument one in position 1 matches parameter in position 0
+.../example.go:9:6: passes 'two' as 'one' in call to foo(one int, two int) (position 0 vs 1)
+.../example.go:9:11: passes 'one' as 'two' in call to foo(one int, two int) (position 1 vs 0)
 exit status 3
 ```
 

--- a/pswap/pswap.go
+++ b/pswap/pswap.go
@@ -197,7 +197,7 @@ func (v *pswapAnalyzer) run(pass *analysis.Pass) (any, error) {
 				}
 				if pi, _ := funParams.Index(ai, matchers()...); pi >= 0 {
 					if pi != ai && pi < len(c.Args) && argName(c.Args[pi]) != name {
-						report(n, name, ai, funObj, pi)
+						report(x, name, ai, funObj, pi)
 					}
 				}
 			}

--- a/pswap/pswap.go
+++ b/pswap/pswap.go
@@ -28,10 +28,9 @@ type pswapAnalyzer struct {
 func Analyzer() *pswapAnalyzer {
 	a := &pswapAnalyzer{
 		Analyzer: &analysis.Analyzer{
-			Name:      "varfmt",
-			Doc:       doc,
-			Requires:  []*analysis.Analyzer{inspect.Analyzer},
-			FactTypes: []analysis.Fact{new(paramList)},
+			Name:     "varfmt",
+			Doc:      doc,
+			Requires: []*analysis.Analyzer{inspect.Analyzer},
 		},
 	}
 	a.Flags.BoolVar(&a.ExactTypeOnly, "exact", false, "suppress pswap reports when types aren't an exact match")
@@ -43,46 +42,47 @@ func Analyzer() *pswapAnalyzer {
 }
 
 type (
-	paramList []param
-	param     struct {
-		Name string
-		Type types.Type
-	}
-	arg          param
-	paramMatcher func(param) bool
+	arg          types.Var
+	param        types.Var
+	paramMatcher func(*param) bool
 )
 
-func (*paramList) AFact() {}
-
-func (pl *paramList) Index(ai int, matchers ...paramMatcher) (int, param) {
+func findParam(fun *types.Func, argIndex int, matchers ...paramMatcher) (int, *param) {
+	params := fun.Signature().Params()
 	for _, match := range matchers {
 		// prefer matching index when available over, e.g. similarly case mismatch in earlier param
-		if ai < len(*pl) && match((*pl)[ai]) {
-			return ai, (*pl)[ai]
+		if argIndex < params.Len() && match((*param)(params.At(argIndex))) {
+			return argIndex, (*param)(params.At(argIndex))
 		}
-		for i, p := range *pl {
-			if match(p) {
-				return i, p
+		for i := range params.Len() {
+			p := params.At(i)
+			if match((*param)(p)) {
+				return i, (*param)(p)
 			}
 		}
 	}
-	return -1, param{}
+	return -1, nil
 }
 
-func (a arg) CaseMatch(p param) bool {
-	return a.Name == p.Name && types.AssignableTo(a.Type, p.Type)
+func (a *arg) Name() string       { return (*types.Var)(a).Name() }
+func (p *param) Name() string     { return (*types.Var)(p).Name() }
+func (a *arg) Type() types.Type   { return (*types.Var)(a).Type() }
+func (p *param) Type() types.Type { return (*types.Var)(p).Type() }
+
+func (a *arg) CaseMatch(p *param) bool {
+	return a.Name() == p.Name() && types.AssignableTo(a.Type(), p.Type())
 }
 
-func (a arg) NoCaseMatch(p param) bool {
-	return strings.EqualFold(a.Name, p.Name) && types.AssignableTo(a.Type, p.Type)
+func (a arg) NoCaseMatch(p *param) bool {
+	return strings.EqualFold(a.Name(), p.Name()) && types.AssignableTo(a.Type(), p.Type())
 }
 
-func (a arg) CaseTypeMatch(p param) bool {
-	return a.Name == p.Name && a.Type == p.Type
+func (a arg) CaseTypeMatch(p *param) bool {
+	return a.Name() == p.Name() && a.Type() == p.Type()
 }
 
-func (a arg) NoCaseTypeMatch(p param) bool {
-	return strings.EqualFold(a.Name, p.Name) && a.Type == p.Type
+func (a arg) NoCaseTypeMatch(p *param) bool {
+	return strings.EqualFold(a.Name(), p.Name()) && a.Type() == p.Type()
 }
 
 func (v *pswapAnalyzer) run(pass *analysis.Pass) (any, error) {
@@ -105,23 +105,8 @@ func (v *pswapAnalyzer) run(pass *analysis.Pass) (any, error) {
 		}
 		return false
 	}
-	// track local function's parameters
-	locals := make(map[types.Object]paramList)
-	paramsOf := func(fun *ast.FuncType) (l paramList) {
-		if fun.Params == nil || len(fun.Params.List) == 0 {
-			return nil
-		}
 
-		for _, p := range fun.Params.List {
-			t := pass.TypesInfo.TypeOf(p.Type)
-			for _, n := range p.Names {
-				l = append(l, param{n.Name, t})
-			}
-		}
-		return l
-	}
-
-	callFunObj := func(c *ast.CallExpr) *types.Func {
+	funOf := func(c *ast.CallExpr) *types.Func {
 		switch f := c.Fun.(type) {
 		case *ast.Ident:
 			return pass.TypesInfo.ObjectOf(f).(*types.Func)
@@ -135,17 +120,19 @@ func (v *pswapAnalyzer) run(pass *analysis.Pass) (any, error) {
 		return nil
 	}
 
-	argName := func(x ast.Expr) string {
+	varOf := func(x ast.Expr) *types.Var {
 		switch x := x.(type) {
 		case *ast.Ident:
-			return x.Name
+			return pass.TypesInfo.ObjectOf(x).(*types.Var)
 		case *ast.SelectorExpr:
-			return x.Sel.Name
+			return pass.TypesInfo.ObjectOf(x.Sel).(*types.Var)
+		case *ast.BasicLit:
+			return nil
 		}
-		return ""
+		return nil
 	}
 
-	report := func(n ast.Node, argName, paramName string, ai int, f *types.Func, pi int) {
+	report := func(n ast.Node, arg *arg, ai int, f *types.Func, pi int) {
 		// similar to t.String, but omits package names
 		var recvType func(t types.Type) string
 		recvType = func(t types.Type) string {
@@ -167,58 +154,49 @@ func (v *pswapAnalyzer) run(pass *analysis.Pass) (any, error) {
 			funcName = "func"
 		}
 
+		params := f.Signature().Params()
+		ppass := func() *types.Var {
+			if ai >= params.Len() {
+				return params.At(params.Len() - 1)
+			} else {
+				return params.At(ai)
+			}
+		}()
+
 		pass.Reportf(
 			n.Pos(),
 			"passes '%s' as '%s' in call to %s%s%s (position %d vs %d)",
-			argName, paramName,
+			arg.Name(), ppass.Name(),
 			funcType, funcName, funcSig,
 			ai, pi,
 		)
 	}
 
 	inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
-	inspect.Preorder([]ast.Node{new(ast.FuncDecl)}, func(n ast.Node) {
-		f := n.(*ast.FuncDecl)
-		obj := pass.TypesInfo.ObjectOf(f.Name)
-		if obj != nil {
-			if ps := paramsOf(f.Type); len(ps) > 0 {
-				pass.ExportObjectFact(obj, &ps)
-				locals[obj] = ps
-			}
-		}
-	})
 	inspect.Preorder([]ast.Node{new(ast.CallExpr)}, func(n ast.Node) {
 		if !v.IncludeGeneratedFiles && isCallGenerated(n) {
 			return
 		}
-		c := n.(*ast.CallExpr)
-		funObj := callFunObj(c)
-		if funObj == nil {
+		call := n.(*ast.CallExpr)
+		fun := funOf(call)
+		if fun == nil {
 			return
 		}
-		funParams, ok := locals[funObj]
-		if !ok {
-			pass.ImportObjectFact(funObj, &funParams)
-		}
-		for ai, x := range c.Args {
-			if aname := argName(x); aname != "" {
-				a := arg{Name: aname, Type: pass.TypesInfo.TypeOf(x)}
-				matchers := func() []paramMatcher {
-					if v.ExactTypeOnly {
-						return []paramMatcher{a.CaseTypeMatch, a.NoCaseTypeMatch}
-					}
-					return []paramMatcher{a.CaseMatch, a.NoCaseMatch}
+		for ai, x := range call.Args {
+			argVar := varOf(x)
+			if argVar == nil {
+				continue
+			}
+			a := (*arg)(argVar)
+			matchers := func() []paramMatcher {
+				if v.ExactTypeOnly {
+					return []paramMatcher{a.CaseTypeMatch, a.NoCaseTypeMatch}
 				}
-				if pi, _ := funParams.Index(ai, matchers()...); pi >= 0 {
-					if pi != ai && pi < len(c.Args) && argName(c.Args[pi]) != aname {
-						pname := ""
-						if ai >= len(funParams) {
-							pname = "..." + funParams[len(funParams)-1].Name
-						} else {
-							pname = funParams[ai].Name
-						}
-						report(x, aname, pname, ai, funObj, pi)
-					}
+				return []paramMatcher{a.CaseMatch, a.NoCaseMatch}
+			}
+			if pi, _ := findParam(fun, ai, matchers()...); pi >= 0 {
+				if pi != ai && pi < len(call.Args) && varOf(call.Args[pi]).Name() != a.Name() {
+					report(x, a, ai, fun, pi)
 				}
 			}
 		}

--- a/pswap/pswap.go
+++ b/pswap/pswap.go
@@ -29,7 +29,7 @@ type pswapAnalyzer struct {
 func Analyzer() *pswapAnalyzer {
 	a := &pswapAnalyzer{
 		Analyzer: &analysis.Analyzer{
-			Name:     "varfmt",
+			Name:     "pswap",
 			Doc:      doc,
 			Requires: []*analysis.Analyzer{inspect.Analyzer},
 		},

--- a/pswap/testdata/src/a/a.go
+++ b/pswap/testdata/src/a/a.go
@@ -20,7 +20,7 @@ func tests() {
 
 	abc(a, b, c) // good
 	abc(a, a, c) // dup name is visible
-	abc(b, a, c) // want "abc argument a in position 1 matches parameter in position 0" "argument b in position 0 matches parameter in position 1"
+	abc(b, a, c) // want `passes 'b' as 'a' in call to abc\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'a' as 'b' in call to abc\(a string, b string, c string\) \(position 1 vs 0\)`
 
 	ghi(a, b, c) // good
 	ghi(a, a, c) // good
@@ -29,51 +29,55 @@ func tests() {
 	aA, Aa, AA, aa := "aA", "Aa", "AA", "aa"
 	AAaa(aA, Aa) // good -- neither AA or aa is perfect, so accept matching index
 	AAaa(AA, aa) // good
-	AAaa(aa, AA) // want "AAaa argument aa in position 0 matches parameter in position 1" "AAaa argument AA in position 1 matches parameter in position 0"
+	AAaa(aa, AA) // want `passes 'aa' as 'AA' in call to AAaa\(AA string, aa string\) \(position 0 vs 1\)` `passes 'AA' as 'aa' in call to AAaa\(AA string, aa string\) \(position 1 vs 0\)`
 
-	anys(c, b, a) // want "anys argument c in position 0 matches parameter in position 2" "anys argument a in position 2 matches parameter in position 0"
+	anys(c, b, a) // want `passes 'c' as 'a' in call to anys\(a any, b any, c any\) \(position 0 vs 2\)` `passes 'a' as 'c' in call to anys\(a any, b any, c any\) \(position 2 vs 0\)`
+	// "anys argument c in position 0 matches parameter in position 2" "anys argument a in position 2 matches parameter in position 0"
 
+	// TODO: should the message mention pkg.ABC instead of ABC?
 	pkg.ABC(a, b, c) // good
 	pkg.ABC(a, a, c) // dup name is visible
-	pkg.ABC(b, a, c) // want "ABC argument a in position 1 matches parameter in position 0" "argument b in position 0 matches parameter in position 1"
+	pkg.ABC(b, a, c) // want `passes 'b' as 'a' in call to ABC\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'a' as 'b' in call to ABC\(a string, b string, c string\) \(position 1 vs 0\)`
 
 	ABC(a, b, c) // good
 	ABC(a, a, c) // dup name is visible
-	ABC(b, a, c) // want "ABC argument a in position 1 matches parameter in position 0" "argument b in position 0 matches parameter in position 1"
+	ABC(b, a, c) // want `passes 'b' as 'A' in call to ABC\(A string, B string, C string\) \(position 0 vs 1\)` `passes 'a' as 'B' in call to ABC\(A string, B string, C string\) \(position 1 vs 0\)`
 
+	// TODO: should the message mention d.a instead of a?
 	abc(d.a, d.b, d.c) // good
 	abc(d.a, d.a, d.c) // dup name is visible
-	abc(d.b, d.a, d.c) // want "abc argument a in position 1 matches parameter in position 0" "argument b in position 0 matches parameter in position 1"
+	abc(d.b, d.a, d.c) // want `passes 'b' as 'a' in call to abc\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'a' as 'b' in call to abc\(a string, b string, c string\) \(position 1 vs 0\)`
 
 	ABC(d.a, d.b, d.c) // good
 	ABC(d.a, d.a, d.c) // dup name is visible
-	ABC(d.b, d.a, d.c) // want "ABC argument a in position 1 matches parameter in position 0" "argument b in position 0 matches parameter in position 1"
+	ABC(d.b, d.a, d.c) // want `passes 'b' as 'A' in call to ABC\(A string, B string, C string\) \(position 0 vs 1\)` `passes 'a' as 'B' in call to ABC\(A string, B string, C string\) \(position 1 vs 0\)`
 
 	abc(d.A, d.B, d.C) // good
 	abc(d.A, d.A, d.C) // dup name is visible
-	abc(d.B, d.A, d.C) // want "abc argument A in position 1 matches parameter in position 0" "argument B in position 0 matches parameter in position 1"
+	abc(d.B, d.A, d.C) // want `passes 'B' as 'a' in call to abc\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'A' as 'b' in call to abc\(a string, b string, c string\) \(position 1 vs 0\)`
 
 	ABC(d.A, d.B, d.C) // good
 	ABC(d.A, d.A, d.C) // dup name is visible
-	ABC(d.B, d.A, d.C) // want "ABC argument A in position 1 matches parameter in position 0" "argument B in position 0 matches parameter in position 1"
+	ABC(d.B, d.A, d.C) // want `passes 'B' as 'A' in call to ABC\(A string, B string, C string\) \(position 0 vs 1\)` `passes 'A' as 'B' in call to ABC\(A string, B string, C string\) \(position 1 vs 0\)`
 
+	// TODO: should the message mention f().a instead of a?
 	abc(f().a, f().b, f().c) // good
 	abc(f().a, f().a, f().c) // dup name is visible
-	abc(f().A, f().a, f().c) // want "abc argument a in position 1 matches parameter in position 0"
-	abc(f().b, f().a, f().c) // want "abc argument a in position 1 matches parameter in position 0" "argument b in position 0 matches parameter in position 1"
+	abc(f().A, f().a, f().c) // want `passes 'a' as 'b' in call to abc\(a string, b string, c string\) \(position 1 vs 0\)`
+	abc(f().b, f().a, f().c) // want `passes 'a' as 'b' in call to abc\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to abc\(a string, b string, c string\) \(position 0 vs 1\)`
 
 	ABC(f().a, f().b, f().c) // good
 	ABC(f().a, f().a, f().c) // dup name is visible
-	ABC(f().b, f().a, f().c) // want "ABC argument a in position 1 matches parameter in position 0" "argument b in position 0 matches parameter in position 1"
+	ABC(f().b, f().a, f().c) // want `passes 'b' as 'A' in call to ABC\(A string, B string, C string\) \(position 0 vs 1\)` `passes 'a' as 'B' in call to ABC\(A string, B string, C string\) \(position 1 vs 0\)`
 
 	abc(f().A, f().B, f().C) // good
 	abc(f().A, f().A, f().C) // dup name is visible
-	abc(f().B, f().A, f().C) // want "abc argument A in position 1 matches parameter in position 0" "argument B in position 0 matches parameter in position 1"
+	abc(f().B, f().A, f().C) // want `passes 'B' as 'a' in call to abc\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'A' as 'b' in call to abc\(a string, b string, c string\) \(position 1 vs 0\)`
 
 	ABC(f().A, f().B, f().C) // good
 	ABC(f().A, f().A, f().C) // dup name is visible
-	ABC(f().a, f().A, f().C) // want "ABC argument A in position 1 matches parameter in position 0"
-	ABC(f().B, f().A, f().C) // want "ABC argument A in position 1 matches parameter in position 0" "argument B in position 0 matches parameter in position 1"
+	ABC(f().a, f().A, f().C) // want `passes 'A' as 'B' in call to ABC\(A string, B string, C string\) \(position 1 vs 0\)`
+	ABC(f().B, f().A, f().C) // want `passes 'A' as 'B' in call to ABC\(A string, B string, C string\) \(position 1 vs 0\)` `passes 'B' as 'A' in call to ABC\(A string, B string, C string\) \(position 0 vs 1\)`
 }
 
 type mock struct {

--- a/pswap/testdata/src/a/a.go
+++ b/pswap/testdata/src/a/a.go
@@ -118,6 +118,15 @@ func tests() {
 	f(a, b, c) // good
 	f(a, a, c) // dup name is visible
 	f(b, a, c) // want `passes 'a' as 'b' in call to f\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to f\(a string, b string, c string\) \(position 0 vs 1\)`
+
+	var i interface {
+		blank(string, string, string)
+		abc(a, b, c string)
+	}
+	i.blank(a, b, c) // fine
+	i.blank(c, b, a) // fine
+	i.abc(a, b, c)   // good
+	i.abc(b, a, c)   // want `passes 'a' as 'b' in call to abc\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to abc\(a string, b string, c string\) \(position 0 vs 1\)`
 }
 
 type mock struct {

--- a/pswap/testdata/src/a/a.go
+++ b/pswap/testdata/src/a/a.go
@@ -15,6 +15,10 @@ type D struct {
 
 func f() D { return D{} }
 
+// generics
+func TTT[T any](a, b, c T)           {}
+func TUV[T, U, V any](a T, b U, c V) {}
+
 func tests() {
 	a, b, c, d := "a", "b", "c", D{}
 
@@ -78,6 +82,14 @@ func tests() {
 	ABC(f().A, f().A, f().C) // dup name is visible
 	ABC(f().a, f().A, f().C) // want `passes 'A' as 'B' in call to ABC\(A string, B string, C string\) \(position 1 vs 0\)`
 	ABC(f().B, f().A, f().C) // want `passes 'A' as 'B' in call to ABC\(A string, B string, C string\) \(position 1 vs 0\)` `passes 'B' as 'A' in call to ABC\(A string, B string, C string\) \(position 0 vs 1\)`
+
+	TTT(a, b, c) // good
+	TTT(a, a, c) // dup name is visible
+	TTT(b, a, c) // want `passes 'a' as 'b' in call to TTT\[string\]\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to TTT\[string\]\(a string, b string, c string\) \(position 0 vs 1\)`
+
+	TUV(a, b, c) // good
+	TUV(a, a, c) // dup name is visible
+	TUV(b, a, c) // want `passes 'a' as 'b' in call to TUV\[string, string, string\]\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to TUV\[string, string, string\]\(a string, b string, c string\) \(position 0 vs 1\)`
 }
 
 type mock struct {

--- a/pswap/testdata/src/a/a.go
+++ b/pswap/testdata/src/a/a.go
@@ -127,6 +127,8 @@ func tests() {
 	i.blank(c, b, a) // fine
 	i.abc(a, b, c)   // good
 	i.abc(b, a, c)   // want `passes 'a' as 'b' in call to abc\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to abc\(a string, b string, c string\) \(position 0 vs 1\)`
+
+	func(c string, _ ...string) {}(a, b, c) // want `passes 'c' as '_' in call to func\(c string, _ \[\]string\) \(position 2 vs 0\)`
 }
 
 type mock struct {

--- a/pswap/testdata/src/a/a.go
+++ b/pswap/testdata/src/a/a.go
@@ -104,6 +104,10 @@ func tests() {
 	g.pabc(a, b, c) // good
 	g.pabc(a, a, c) // dup name is visible
 	g.pabc(b, a, c) // want `passes 'a' as 'b' in call to \(\*G\[string\]\).pabc\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to \(\*G\[string\]\).pabc\(a string, b string, c string\) \(position 0 vs 1\)`
+
+	func(a, b, c string) {}(a, b, c) // good
+	func(a, b, c string) {}(a, a, c) // dup name is visible
+	func(a, b, c string) {}(b, a, c) // want `passes 'a' as 'b' in call to func\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to func\(a string, b string, c string\) \(position 0 vs 1\)`
 }
 
 type mock struct {

--- a/pswap/testdata/src/a/a.go
+++ b/pswap/testdata/src/a/a.go
@@ -19,6 +19,11 @@ func f() D { return D{} }
 func TTT[T any](a, b, c T)           {}
 func TUV[T, U, V any](a T, b U, c V) {}
 
+type G[T any] struct{}
+
+func (G[T]) abc(a, b, c T)   {}
+func (*G[T]) pabc(a, b, c T) {}
+
 func tests() {
 	a, b, c, d := "a", "b", "c", D{}
 
@@ -90,6 +95,15 @@ func tests() {
 	TUV(a, b, c) // good
 	TUV(a, a, c) // dup name is visible
 	TUV(b, a, c) // want `passes 'a' as 'b' in call to TUV\[string, string, string\]\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to TUV\[string, string, string\]\(a string, b string, c string\) \(position 0 vs 1\)`
+
+	g := G[string]{}
+	g.abc(a, b, c) // good
+	g.abc(a, a, c) // dup name is visible
+	g.abc(b, a, c) // want `passes 'a' as 'b' in call to \(G\[string\]\).abc\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to \(G\[string\]\).abc\(a string, b string, c string\) \(position 0 vs 1\)`
+
+	g.pabc(a, b, c) // good
+	g.pabc(a, a, c) // dup name is visible
+	g.pabc(b, a, c) // want `passes 'a' as 'b' in call to \(\*G\[string\]\).pabc\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to \(\*G\[string\]\).pabc\(a string, b string, c string\) \(position 0 vs 1\)`
 }
 
 type mock struct {

--- a/pswap/testdata/src/a/a.go
+++ b/pswap/testdata/src/a/a.go
@@ -2,11 +2,11 @@ package a
 
 import "a/pkg"
 
-func abc(a, b, c string) {} // want abc:`&\[\{a string} \{b string} \{c string}]`
-func ABC(A, B, C string) {} // want ABC:`&\[\{A string} \{B string} \{C string}]`
-func ghi(g, h, i string) {} // want ghi:`&\[\{g string} \{h string} \{i string}]`
-func AAaa(AA, aa string) {} // want AAaa:`&\[\{AA string} \{aa string}]`
-func anys(a, b, c any)   {} // want anys:`&\[\{a any} \{b any} \{c any}]`
+func abc(a, b, c string) {}
+func ABC(A, B, C string) {}
+func ghi(g, h, i string) {}
+func AAaa(AA, aa string) {}
+func anys(a, b, c any)   {}
 
 type D struct {
 	a, b, c string
@@ -84,13 +84,13 @@ type mock struct {
 	x *expectations
 }
 
-func (m *mock) ExpectFoo(t TB, fn func(int, string) string) { // want ExpectFoo:`&\[\{t a.TB\} \{fn func\(int, string\) string}]`
+func (m *mock) ExpectFoo(t TB, fn func(int, string) string) {
 	m.x.Expect(t, "Foo", fn) // skip mismatched type (string != func)
 }
 
 type expectations struct{}
 
-func (x *expectations) Expect(t TB, fn string, e ...any) {} // want Expect:`&\[\{t a.TB\} \{fn string\} \{e \[\]any}]`
+func (x *expectations) Expect(t TB, fn string, e ...any) {}
 
 type TB interface{ Helper() }
 

--- a/pswap/testdata/src/a/a.go
+++ b/pswap/testdata/src/a/a.go
@@ -108,6 +108,16 @@ func tests() {
 	func(a, b, c string) {}(a, b, c) // good
 	func(a, b, c string) {}(a, a, c) // dup name is visible
 	func(a, b, c string) {}(b, a, c) // want `passes 'a' as 'b' in call to func\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to func\(a string, b string, c string\) \(position 0 vs 1\)`
+
+	f := func(a, b, c string) {}
+	f(a, b, c) // good
+	f(a, a, c) // dup name is visible
+	f(b, a, c) // want `passes 'a' as 'b' in call to f\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to f\(a string, b string, c string\) \(position 0 vs 1\)`
+
+	f = g.pabc
+	f(a, b, c) // good
+	f(a, a, c) // dup name is visible
+	f(b, a, c) // want `passes 'a' as 'b' in call to f\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to f\(a string, b string, c string\) \(position 0 vs 1\)`
 }
 
 type mock struct {

--- a/pswap/testdata/src/exact/e.go
+++ b/pswap/testdata/src/exact/e.go
@@ -1,7 +1,7 @@
 package exact
 
-func abc(a, b, c string) {} // want abc:`&\[\{a string} \{b string} \{c string}]`
-func anys(a, b, c any)   {} // want anys:`&\[\{a any} \{b any} \{c any}]`
+func abc(a, b, c string) {}
+func anys(a, b, c any)   {}
 
 func tests() {
 	a, b, c := "a", "b", "c"

--- a/pswap/testdata/src/exact/e.go
+++ b/pswap/testdata/src/exact/e.go
@@ -8,7 +8,7 @@ func tests() {
 
 	abc(a, b, c) // good
 	abc(a, a, c) // dup name is visible
-	abc(b, a, c) // want "abc argument a in position 1 matches parameter in position 0" "argument b in position 0 matches parameter in position 1"
+	abc(b, a, c) // want `passes 'b' as 'a' in call to abc\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'a' as 'b' in call to abc\(a string, b string, c string\) \(position 1 vs 0\)`
 
 	anys(c, b, a) // ignored string->any
 }


### PR DESCRIPTION
- Report column of argument, not of function call
- Change message for readability: passes 'a' as 'b' in call to ... (position i vs j)
- Update readme accordingly
- Leverage *types.Func and *types.Sig; no need for passing a Fact
- Handle generic functions and receivers on generic types
- Handle directly invoked (fully anonymous) function literals
- Handle indirectly invoked functions
- Prove handling of interfaces
- Tidy handling of variadics
