### PR TITLE
Improve linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ parameter-swap will report the following:
 
 ```console
 $ parameter-swap ./...
-.../example.go:9:6: passes 'two' as 'one' in call to func <PATH>.foo(one int, two int) int (position 0 vs 1)
-.../example.go:9:11: passes 'one' as 'two' in call to func <PATH>.foo(one int, two int) int (position 1 vs 0)
+.../example.go:9:6: passes 'two' as 'one' in call to func foo(one int, two int) int (position 0 vs 1)
+.../example.go:9:11: passes 'one' as 'two' in call to func foo(one int, two int) int (position 1 vs 0)
 exit status 3
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ parameter-swap will report the following:
 
 ```console
 $ parameter-swap ./...
-.../example.go:9:6: passes 'two' as 'one' in call to foo(one int, two int) (position 0 vs 1)
-.../example.go:9:11: passes 'one' as 'two' in call to foo(one int, two int) (position 1 vs 0)
+.../example.go:9:6: passes 'two' as 'one' in call to func <PATH>.foo(one int, two int) int (position 0 vs 1)
+.../example.go:9:11: passes 'one' as 'two' in call to func <PATH>.foo(one int, two int) int (position 1 vs 0)
 exit status 3
 ```
 

--- a/pswap/pswap.go
+++ b/pswap/pswap.go
@@ -162,9 +162,11 @@ func (v *pswapAnalyzer) run(pass *analysis.Pass) (any, error) {
 	varOf := func(x ast.Expr) *types.Var {
 		switch x := x.(type) {
 		case *ast.Ident:
-			return pass.TypesInfo.ObjectOf(x).(*types.Var)
+			v, _ := pass.TypesInfo.ObjectOf(x).(*types.Var)
+			return v
 		case *ast.SelectorExpr:
-			return pass.TypesInfo.ObjectOf(x.Sel).(*types.Var)
+			v, _ := pass.TypesInfo.ObjectOf(x.Sel).(*types.Var)
+			return v
 		case *ast.BasicLit:
 			return nil
 		}

--- a/pswap/testdata/src/a/a.go
+++ b/pswap/testdata/src/a/a.go
@@ -32,7 +32,7 @@ func tests() {
 
 	abc(a, b, c) // good
 	abc(a, a, c) // dup name is visible
-	abc(b, a, c) // want `passes 'b' as 'a' in call to abc\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'a' as 'b' in call to abc\(a string, b string, c string\) \(position 1 vs 0\)`
+	abc(b, a, c) // want `passes 'b' as 'a' in call to func a.abc\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'a' as 'b' in call to func a.abc\(a string, b string, c string\) \(position 1 vs 0\)`
 
 	ghi(a, b, c) // good
 	ghi(a, a, c) // good
@@ -41,72 +41,72 @@ func tests() {
 	aA, Aa, AA, aa := "aA", "Aa", "AA", "aa"
 	AAaa(aA, Aa) // good -- neither AA or aa is perfect, so accept matching index
 	AAaa(AA, aa) // good
-	AAaa(aa, AA) // want `passes 'aa' as 'AA' in call to AAaa\(AA string, aa string\) \(position 0 vs 1\)` `passes 'AA' as 'aa' in call to AAaa\(AA string, aa string\) \(position 1 vs 0\)`
+	AAaa(aa, AA) // want `passes 'aa' as 'AA' in call to func a.AAaa\(AA string, aa string\) \(position 0 vs 1\)` `passes 'AA' as 'aa' in call to func a.AAaa\(AA string, aa string\) \(position 1 vs 0\)`
 
-	anys(c, b, a) // want `passes 'c' as 'a' in call to anys\(a any, b any, c any\) \(position 0 vs 2\)` `passes 'a' as 'c' in call to anys\(a any, b any, c any\) \(position 2 vs 0\)`
-	// "anys argument c in position 0 matches parameter in position 2" "anys argument a in position 2 matches parameter in position 0"
+	anys(c, b, a) // want `passes 'c' as 'a' in call to func a.anys\(a any, b any, c any\) \(position 0 vs 2\)` `passes 'a' as 'c' in call to func a.anys\(a any, b any, c any\) \(position 2 vs 0\)`
 
 	// TODO: should the message mention pkg.ABC instead of ABC?
 	pkg.ABC(a, b, c) // good
 	pkg.ABC(a, a, c) // dup name is visible
-	pkg.ABC(b, a, c) // want `passes 'b' as 'a' in call to ABC\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'a' as 'b' in call to ABC\(a string, b string, c string\) \(position 1 vs 0\)`
+	pkg.ABC(b, a, c) // want `passes 'b' as 'a' in call to func a/pkg.ABC\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'a' as 'b' in call to func a/pkg.ABC\(a string, b string, c string\) \(position 1 vs 0\)`
 
 	ABC(a, b, c) // good
 	ABC(a, a, c) // dup name is visible
-	ABC(b, a, c) // want `passes 'b' as 'A' in call to ABC\(A string, B string, C string\) \(position 0 vs 1\)` `passes 'a' as 'B' in call to ABC\(A string, B string, C string\) \(position 1 vs 0\)`
+	ABC(b, a, c) // want `passes 'b' as 'A' in call to func a.ABC\(A string, B string, C string\) \(position 0 vs 1\)` `passes 'a' as 'B' in call to func a.ABC\(A string, B string, C string\) \(position 1 vs 0\)`
 
 	// TODO: should the message mention d.a instead of a?
 	abc(d.a, d.b, d.c) // good
 	abc(d.a, d.a, d.c) // dup name is visible
-	abc(d.b, d.a, d.c) // want `passes 'b' as 'a' in call to abc\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'a' as 'b' in call to abc\(a string, b string, c string\) \(position 1 vs 0\)`
+	abc(d.b, d.a, d.c) // want `passes 'b' as 'a' in call to func a.abc\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'a' as 'b' in call to func a.abc\(a string, b string, c string\) \(position 1 vs 0\)`
 
 	ABC(d.a, d.b, d.c) // good
 	ABC(d.a, d.a, d.c) // dup name is visible
-	ABC(d.b, d.a, d.c) // want `passes 'b' as 'A' in call to ABC\(A string, B string, C string\) \(position 0 vs 1\)` `passes 'a' as 'B' in call to ABC\(A string, B string, C string\) \(position 1 vs 0\)`
+	ABC(d.b, d.a, d.c) // want `passes 'b' as 'A' in call to func a.ABC\(A string, B string, C string\) \(position 0 vs 1\)` `passes 'a' as 'B' in call to func a.ABC\(A string, B string, C string\) \(position 1 vs 0\)`
 
 	abc(d.A, d.B, d.C) // good
 	abc(d.A, d.A, d.C) // dup name is visible
-	abc(d.B, d.A, d.C) // want `passes 'B' as 'a' in call to abc\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'A' as 'b' in call to abc\(a string, b string, c string\) \(position 1 vs 0\)`
+	abc(d.B, d.A, d.C) // want `passes 'B' as 'a' in call to func a.abc\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'A' as 'b' in call to func a.abc\(a string, b string, c string\) \(position 1 vs 0\)`
 
 	ABC(d.A, d.B, d.C) // good
 	ABC(d.A, d.A, d.C) // dup name is visible
-	ABC(d.B, d.A, d.C) // want `passes 'B' as 'A' in call to ABC\(A string, B string, C string\) \(position 0 vs 1\)` `passes 'A' as 'B' in call to ABC\(A string, B string, C string\) \(position 1 vs 0\)`
+	ABC(d.B, d.A, d.C) // want `passes 'B' as 'A' in call to func a.ABC\(A string, B string, C string\) \(position 0 vs 1\)` `passes 'A' as 'B' in call to func a.ABC\(A string, B string, C string\) \(position 1 vs 0\)`
 
 	// TODO: should the message mention f().a instead of a?
 	abc(f().a, f().b, f().c) // good
 	abc(f().a, f().a, f().c) // dup name is visible
-	abc(f().A, f().a, f().c) // want `passes 'a' as 'b' in call to abc\(a string, b string, c string\) \(position 1 vs 0\)`
-	abc(f().b, f().a, f().c) // want `passes 'a' as 'b' in call to abc\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to abc\(a string, b string, c string\) \(position 0 vs 1\)`
+	abc(f().A, f().a, f().c) // want `passes 'a' as 'b' in call to func a.abc\(a string, b string, c string\) \(position 1 vs 0\)`
+	abc(f().b, f().a, f().c) // want `passes 'a' as 'b' in call to func a.abc\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to func a.abc\(a string, b string, c string\) \(position 0 vs 1\)`
 
 	ABC(f().a, f().b, f().c) // good
 	ABC(f().a, f().a, f().c) // dup name is visible
-	ABC(f().b, f().a, f().c) // want `passes 'b' as 'A' in call to ABC\(A string, B string, C string\) \(position 0 vs 1\)` `passes 'a' as 'B' in call to ABC\(A string, B string, C string\) \(position 1 vs 0\)`
+	ABC(f().b, f().a, f().c) // want `passes 'b' as 'A' in call to func a.ABC\(A string, B string, C string\) \(position 0 vs 1\)` `passes 'a' as 'B' in call to func a.ABC\(A string, B string, C string\) \(position 1 vs 0\)`
 
 	abc(f().A, f().B, f().C) // good
 	abc(f().A, f().A, f().C) // dup name is visible
-	abc(f().B, f().A, f().C) // want `passes 'B' as 'a' in call to abc\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'A' as 'b' in call to abc\(a string, b string, c string\) \(position 1 vs 0\)`
+	abc(f().B, f().A, f().C) // want `passes 'B' as 'a' in call to func a.abc\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'A' as 'b' in call to func a.abc\(a string, b string, c string\) \(position 1 vs 0\)`
 
 	ABC(f().A, f().B, f().C) // good
 	ABC(f().A, f().A, f().C) // dup name is visible
-	ABC(f().a, f().A, f().C) // want `passes 'A' as 'B' in call to ABC\(A string, B string, C string\) \(position 1 vs 0\)`
-	ABC(f().B, f().A, f().C) // want `passes 'A' as 'B' in call to ABC\(A string, B string, C string\) \(position 1 vs 0\)` `passes 'B' as 'A' in call to ABC\(A string, B string, C string\) \(position 0 vs 1\)`
+	ABC(f().a, f().A, f().C) // want `passes 'A' as 'B' in call to func a.ABC\(A string, B string, C string\) \(position 1 vs 0\)`
+	ABC(f().B, f().A, f().C) // want `passes 'A' as 'B' in call to func a.ABC\(A string, B string, C string\) \(position 1 vs 0\)` `passes 'B' as 'A' in call to func a.ABC\(A string, B string, C string\) \(position 0 vs 1\)`
 
 	TTT(a, b, c) // good
 	TTT(a, a, c) // dup name is visible
-	TTT(b, a, c) // want `passes 'a' as 'b' in call to TTT\[string\]\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to TTT\[string\]\(a string, b string, c string\) \(position 0 vs 1\)`
+	TTT(b, a, c) // want `passes 'a' as 'b' in call to func a.TTT\[T string\]\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to func a.TTT\[T string\]\(a string, b string, c string\) \(position 0 vs 1\)`
 
 	TUV(a, b, c) // good
 	TUV(a, a, c) // dup name is visible
-	TUV(b, a, c) // want `passes 'a' as 'b' in call to TUV\[string, string, string\]\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to TUV\[string, string, string\]\(a string, b string, c string\) \(position 0 vs 1\)`
+	TUV(4, a, c) // param name a mismatches type
+	TUV(b, a, c) // want `passes 'a' as 'b' in call to func a.TUV\[T string, U string, V string\]\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to func a.TUV\[T string, U string, V string\]\(a string, b string, c string\) \(position 0 vs 1\)`
 
 	g := G[string]{}
 	g.abc(a, b, c) // good
 	g.abc(a, a, c) // dup name is visible
-	g.abc(b, a, c) // want `passes 'a' as 'b' in call to \(G\[string\]\).abc\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to \(G\[string\]\).abc\(a string, b string, c string\) \(position 0 vs 1\)`
+	g.abc(b, a, c) // want `passes 'a' as 'b' in call to func \(a.G\[string\]\).abc\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to func \(a.G\[string\]\).abc\(a string, b string, c string\) \(position 0 vs 1\)`
 
 	g.pabc(a, b, c) // good
 	g.pabc(a, a, c) // dup name is visible
-	g.pabc(b, a, c) // want `passes 'a' as 'b' in call to \(\*G\[string\]\).pabc\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to \(\*G\[string\]\).pabc\(a string, b string, c string\) \(position 0 vs 1\)`
+	g.pabc(b, a, c) // want `passes 'a' as 'b' in call to func \(\*a.G\[string\]\).pabc\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to func \(\*a.G\[string\]\).pabc\(a string, b string, c string\) \(position 0 vs 1\)`
 
 	func(a, b, c string) {}(a, b, c) // good
 	func(a, b, c string) {}(a, a, c) // dup name is visible
@@ -115,12 +115,12 @@ func tests() {
 	f := func(a, b, c string) {}
 	f(a, b, c) // good
 	f(a, a, c) // dup name is visible
-	f(b, a, c) // want `passes 'a' as 'b' in call to f\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to f\(a string, b string, c string\) \(position 0 vs 1\)`
+	f(b, a, c) // want `passes 'a' as 'b' in call to func f\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to func f\(a string, b string, c string\) \(position 0 vs 1\)`
 
 	f = g.pabc
 	f(a, b, c) // good
 	f(a, a, c) // dup name is visible
-	f(b, a, c) // want `passes 'a' as 'b' in call to f\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to f\(a string, b string, c string\) \(position 0 vs 1\)`
+	f(b, a, c) // want `passes 'a' as 'b' in call to func f\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to func f\(a string, b string, c string\) \(position 0 vs 1\)`
 
 	var i interface {
 		blank(string, string, string)
@@ -129,9 +129,9 @@ func tests() {
 	i.blank(a, b, c) // fine
 	i.blank(c, b, a) // fine
 	i.abc(a, b, c)   // good
-	i.abc(b, a, c)   // want `passes 'a' as 'b' in call to abc\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to abc\(a string, b string, c string\) \(position 0 vs 1\)`
+	i.abc(b, a, c)   // want `passes 'a' as 'b' in call to func \(interface\).abc\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to func \(interface\).abc\(a string, b string, c string\) \(position 0 vs 1\)`
 
-	func(c string, _ ...string) {}(a, b, c) // want `passes 'c' as '_' in call to func\(c string, _ \[\]string\) \(position 2 vs 0\)`
+	func(c string, _ ...string) {}(a, b, c) // want `passes 'c' as '_' in call to func\(c string, _ \.\.\.string\) \(position 2 vs 0\)`
 
 	slices.IndexFunc(([]int)(nil), ifunc) // provokes *ast.Ident -> *types.Func in varOf (previously assumed *types.Var)
 
@@ -140,6 +140,23 @@ func tests() {
 
 	func(pro, con string) {}(con, "")   // want `passes 'con' as 'pro' in call to func\(pro string, con string\) \(position 0 vs 1\)`
 	func(abc, xyz any) {}(nil, pkg.ABC) // want `passes 'ABC' as 'xyz' in call to func\(abc any, xyz any\) \(position 1 vs 0\)`
+
+	{
+		b, c := mock{}, mock{}
+		TTT(b, c, c) // want `passes 'b' as 'a' in call to func a.TTT\[T a.mock\]\(a a.mock, b a.mock, c a.mock\) \(position 0 vs 1\)`
+	}
+	{
+		var b, c pkg.Struct
+		TTT(b, c, c) // want `passes 'b' as 'a' in call to func a.TTT\[T a/pkg.Struct\]\(a a/pkg.Struct, b a/pkg.Struct, c a/pkg.Struct\) \(position 0 vs 1\)`
+	}
+	{
+		var b, c map[pkg.Struct][]pkg.Struct
+		TTT(b, c, c) // want `passes 'b' as 'a' in call to func a.TTT\[T map\[a/pkg.Struct\]\[\]a/pkg.Struct\]\(a map\[a/pkg.Struct\]\[\]a/pkg.Struct, b map\[a/pkg.Struct\]\[\]a/pkg.Struct, c map\[a/pkg.Struct\]\[\]a/pkg.Struct\) \(position 0 vs 1\)`
+	}
+	{
+		var b, c func(pkg.Struct) pkg.Struct
+		TTT(b, c, c) // want `passes 'b' as 'a' in call to func a.TTT\[T func\(a/pkg.Struct\) a/pkg.Struct\]\(a func\(a/pkg.Struct\) a/pkg.Struct, b func\(a/pkg.Struct\) a/pkg.Struct, c func\(a/pkg.Struct\) a/pkg.Struct\) \(position 0 vs 1\)`
+	}
 }
 
 func ifunc(int) bool { return false }

--- a/pswap/testdata/src/a/a.go
+++ b/pswap/testdata/src/a/a.go
@@ -32,7 +32,7 @@ func tests() {
 
 	abc(a, b, c) // good
 	abc(a, a, c) // dup name is visible
-	abc(b, a, c) // want `passes 'b' as 'a' in call to func a.abc\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'a' as 'b' in call to func a.abc\(a string, b string, c string\) \(position 1 vs 0\)`
+	abc(b, a, c) // want `passes 'b' as 'a' in call to func abc\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'a' as 'b' in call to func abc\(a string, b string, c string\) \(position 1 vs 0\)`
 
 	ghi(a, b, c) // good
 	ghi(a, a, c) // good
@@ -41,9 +41,9 @@ func tests() {
 	aA, Aa, AA, aa := "aA", "Aa", "AA", "aa"
 	AAaa(aA, Aa) // good -- neither AA or aa is perfect, so accept matching index
 	AAaa(AA, aa) // good
-	AAaa(aa, AA) // want `passes 'aa' as 'AA' in call to func a.AAaa\(AA string, aa string\) \(position 0 vs 1\)` `passes 'AA' as 'aa' in call to func a.AAaa\(AA string, aa string\) \(position 1 vs 0\)`
+	AAaa(aa, AA) // want `passes 'aa' as 'AA' in call to func AAaa\(AA string, aa string\) \(position 0 vs 1\)` `passes 'AA' as 'aa' in call to func AAaa\(AA string, aa string\) \(position 1 vs 0\)`
 
-	anys(c, b, a) // want `passes 'c' as 'a' in call to func a.anys\(a any, b any, c any\) \(position 0 vs 2\)` `passes 'a' as 'c' in call to func a.anys\(a any, b any, c any\) \(position 2 vs 0\)`
+	anys(c, b, a) // want `passes 'c' as 'a' in call to func anys\(a any, b any, c any\) \(position 0 vs 2\)` `passes 'a' as 'c' in call to func anys\(a any, b any, c any\) \(position 2 vs 0\)`
 
 	// TODO: should the message mention pkg.ABC instead of ABC?
 	pkg.ABC(a, b, c) // good
@@ -52,61 +52,61 @@ func tests() {
 
 	ABC(a, b, c) // good
 	ABC(a, a, c) // dup name is visible
-	ABC(b, a, c) // want `passes 'b' as 'A' in call to func a.ABC\(A string, B string, C string\) \(position 0 vs 1\)` `passes 'a' as 'B' in call to func a.ABC\(A string, B string, C string\) \(position 1 vs 0\)`
+	ABC(b, a, c) // want `passes 'b' as 'A' in call to func ABC\(A string, B string, C string\) \(position 0 vs 1\)` `passes 'a' as 'B' in call to func ABC\(A string, B string, C string\) \(position 1 vs 0\)`
 
 	// TODO: should the message mention d.a instead of a?
 	abc(d.a, d.b, d.c) // good
 	abc(d.a, d.a, d.c) // dup name is visible
-	abc(d.b, d.a, d.c) // want `passes 'b' as 'a' in call to func a.abc\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'a' as 'b' in call to func a.abc\(a string, b string, c string\) \(position 1 vs 0\)`
+	abc(d.b, d.a, d.c) // want `passes 'b' as 'a' in call to func abc\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'a' as 'b' in call to func abc\(a string, b string, c string\) \(position 1 vs 0\)`
 
 	ABC(d.a, d.b, d.c) // good
 	ABC(d.a, d.a, d.c) // dup name is visible
-	ABC(d.b, d.a, d.c) // want `passes 'b' as 'A' in call to func a.ABC\(A string, B string, C string\) \(position 0 vs 1\)` `passes 'a' as 'B' in call to func a.ABC\(A string, B string, C string\) \(position 1 vs 0\)`
+	ABC(d.b, d.a, d.c) // want `passes 'b' as 'A' in call to func ABC\(A string, B string, C string\) \(position 0 vs 1\)` `passes 'a' as 'B' in call to func ABC\(A string, B string, C string\) \(position 1 vs 0\)`
 
 	abc(d.A, d.B, d.C) // good
 	abc(d.A, d.A, d.C) // dup name is visible
-	abc(d.B, d.A, d.C) // want `passes 'B' as 'a' in call to func a.abc\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'A' as 'b' in call to func a.abc\(a string, b string, c string\) \(position 1 vs 0\)`
+	abc(d.B, d.A, d.C) // want `passes 'B' as 'a' in call to func abc\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'A' as 'b' in call to func abc\(a string, b string, c string\) \(position 1 vs 0\)`
 
 	ABC(d.A, d.B, d.C) // good
 	ABC(d.A, d.A, d.C) // dup name is visible
-	ABC(d.B, d.A, d.C) // want `passes 'B' as 'A' in call to func a.ABC\(A string, B string, C string\) \(position 0 vs 1\)` `passes 'A' as 'B' in call to func a.ABC\(A string, B string, C string\) \(position 1 vs 0\)`
+	ABC(d.B, d.A, d.C) // want `passes 'B' as 'A' in call to func ABC\(A string, B string, C string\) \(position 0 vs 1\)` `passes 'A' as 'B' in call to func ABC\(A string, B string, C string\) \(position 1 vs 0\)`
 
 	// TODO: should the message mention f().a instead of a?
 	abc(f().a, f().b, f().c) // good
 	abc(f().a, f().a, f().c) // dup name is visible
-	abc(f().A, f().a, f().c) // want `passes 'a' as 'b' in call to func a.abc\(a string, b string, c string\) \(position 1 vs 0\)`
-	abc(f().b, f().a, f().c) // want `passes 'a' as 'b' in call to func a.abc\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to func a.abc\(a string, b string, c string\) \(position 0 vs 1\)`
+	abc(f().A, f().a, f().c) // want `passes 'a' as 'b' in call to func abc\(a string, b string, c string\) \(position 1 vs 0\)`
+	abc(f().b, f().a, f().c) // want `passes 'a' as 'b' in call to func abc\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to func abc\(a string, b string, c string\) \(position 0 vs 1\)`
 
 	ABC(f().a, f().b, f().c) // good
 	ABC(f().a, f().a, f().c) // dup name is visible
-	ABC(f().b, f().a, f().c) // want `passes 'b' as 'A' in call to func a.ABC\(A string, B string, C string\) \(position 0 vs 1\)` `passes 'a' as 'B' in call to func a.ABC\(A string, B string, C string\) \(position 1 vs 0\)`
+	ABC(f().b, f().a, f().c) // want `passes 'b' as 'A' in call to func ABC\(A string, B string, C string\) \(position 0 vs 1\)` `passes 'a' as 'B' in call to func ABC\(A string, B string, C string\) \(position 1 vs 0\)`
 
 	abc(f().A, f().B, f().C) // good
 	abc(f().A, f().A, f().C) // dup name is visible
-	abc(f().B, f().A, f().C) // want `passes 'B' as 'a' in call to func a.abc\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'A' as 'b' in call to func a.abc\(a string, b string, c string\) \(position 1 vs 0\)`
+	abc(f().B, f().A, f().C) // want `passes 'B' as 'a' in call to func abc\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'A' as 'b' in call to func abc\(a string, b string, c string\) \(position 1 vs 0\)`
 
 	ABC(f().A, f().B, f().C) // good
 	ABC(f().A, f().A, f().C) // dup name is visible
-	ABC(f().a, f().A, f().C) // want `passes 'A' as 'B' in call to func a.ABC\(A string, B string, C string\) \(position 1 vs 0\)`
-	ABC(f().B, f().A, f().C) // want `passes 'A' as 'B' in call to func a.ABC\(A string, B string, C string\) \(position 1 vs 0\)` `passes 'B' as 'A' in call to func a.ABC\(A string, B string, C string\) \(position 0 vs 1\)`
+	ABC(f().a, f().A, f().C) // want `passes 'A' as 'B' in call to func ABC\(A string, B string, C string\) \(position 1 vs 0\)`
+	ABC(f().B, f().A, f().C) // want `passes 'A' as 'B' in call to func ABC\(A string, B string, C string\) \(position 1 vs 0\)` `passes 'B' as 'A' in call to func ABC\(A string, B string, C string\) \(position 0 vs 1\)`
 
 	TTT(a, b, c) // good
 	TTT(a, a, c) // dup name is visible
-	TTT(b, a, c) // want `passes 'a' as 'b' in call to func a.TTT\[T = string\]\(a T, b T, c T\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to func a.TTT\[T = string\]\(a T, b T, c T\) \(position 0 vs 1\)`
+	TTT(b, a, c) // want `passes 'a' as 'b' in call to func TTT\[T = string\]\(a T, b T, c T\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to func TTT\[T = string\]\(a T, b T, c T\) \(position 0 vs 1\)`
 
 	TUV(a, b, c) // good
 	TUV(a, a, c) // dup name is visible
 	TUV(4, a, c) // param name a mismatches type
-	TUV(b, a, c) // want `passes 'a' as 'b' in call to func a.TUV\[T = string, U = string, V = string\]\(a T, b U, c V\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to func a.TUV\[T = string, U = string, V = string\]\(a T, b U, c V\) \(position 0 vs 1\)`
+	TUV(b, a, c) // want `passes 'a' as 'b' in call to func TUV\[T = string, U = string, V = string\]\(a T, b U, c V\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to func TUV\[T = string, U = string, V = string\]\(a T, b U, c V\) \(position 0 vs 1\)`
 
 	g := G[string]{}
 	g.abc(a, b, c) // good
 	g.abc(a, a, c) // dup name is visible
-	g.abc(b, a, c) // want `passes 'a' as 'b' in call to func \(a.G\[string\]\).abc\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to func \(a.G\[string\]\).abc\(a string, b string, c string\) \(position 0 vs 1\)`
+	g.abc(b, a, c) // want `passes 'a' as 'b' in call to func \(G\[string\]\).abc\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to func \(G\[string\]\).abc\(a string, b string, c string\) \(position 0 vs 1\)`
 
 	g.pabc(a, b, c) // good
 	g.pabc(a, a, c) // dup name is visible
-	g.pabc(b, a, c) // want `passes 'a' as 'b' in call to func \(\*a.G\[string\]\).pabc\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to func \(\*a.G\[string\]\).pabc\(a string, b string, c string\) \(position 0 vs 1\)`
+	g.pabc(b, a, c) // want `passes 'a' as 'b' in call to func \(\*G\[string\]\).pabc\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to func \(\*G\[string\]\).pabc\(a string, b string, c string\) \(position 0 vs 1\)`
 
 	func(a, b, c string) {}(a, b, c) // good
 	func(a, b, c string) {}(a, a, c) // dup name is visible
@@ -143,19 +143,19 @@ func tests() {
 
 	{
 		b, c := mock{}, mock{}
-		TTT(b, c, c) // want `passes 'b' as 'a' in call to func a.TTT\[T = a.mock\]\(a T, b T, c T\) \(position 0 vs 1\)`
+		TTT(b, c, c) // want `passes 'b' as 'a' in call to func TTT\[T = mock\]\(a T, b T, c T\) \(position 0 vs 1\)`
 	}
 	{
 		var b, c pkg.Struct
-		TTT(b, c, c) // want `passes 'b' as 'a' in call to func a.TTT\[T = a/pkg.Struct\]\(a T, b T, c T\) \(position 0 vs 1\)`
+		TTT(b, c, c) // want `passes 'b' as 'a' in call to func TTT\[T = a/pkg.Struct\]\(a T, b T, c T\) \(position 0 vs 1\)`
 	}
 	{
 		var b, c map[pkg.Struct][]pkg.Struct
-		TTT(b, c, c) // want `passes 'b' as 'a' in call to func a.TTT\[T = map\[a/pkg.Struct\]\[\]a/pkg.Struct\]\(a T, b T, c T\) \(position 0 vs 1\)`
+		TTT(b, c, c) // want `passes 'b' as 'a' in call to func TTT\[T = map\[a/pkg.Struct\]\[\]a/pkg.Struct\]\(a T, b T, c T\) \(position 0 vs 1\)`
 	}
 	{
 		var b, c func(pkg.Struct) pkg.Struct
-		TTT(b, c, c) // want `passes 'b' as 'a' in call to func a.TTT\[T = func\(a/pkg.Struct\) a/pkg.Struct\]\(a T, b T, c T\) \(position 0 vs 1\)`
+		TTT(b, c, c) // want `passes 'b' as 'a' in call to func TTT\[T = func\(a/pkg.Struct\) a/pkg.Struct\]\(a T, b T, c T\) \(position 0 vs 1\)`
 	}
 }
 

--- a/pswap/testdata/src/a/a.go
+++ b/pswap/testdata/src/a/a.go
@@ -139,7 +139,7 @@ func tests() {
 	// *ast.Ident -> *types.Const, and *ast.Ident -> *types.Nil in varOf.
 
 	func(pro, con string) {}(con, "")   // want `passes 'con' as 'pro' in call to func\(pro string, con string\) \(position 0 vs 1\)`
-	func(abc, xyz any) {}(nil, pkg.ABC) // want `passes 'ABC' as 'xyz' in call to func\(abc any, xyz any\) \(position 1 vs 0\)`
+	func(abc, xyz any) {}(nil, pkg.ABC) // want `passes 'pkg.ABC' as 'xyz' in call to func\(abc any, xyz any\) \(position 1 vs 0\)`
 
 	{
 		b, c := mock{}, mock{}

--- a/pswap/testdata/src/a/a.go
+++ b/pswap/testdata/src/a/a.go
@@ -48,7 +48,7 @@ func tests() {
 	// TODO: should the message mention pkg.ABC instead of ABC?
 	pkg.ABC(a, b, c) // good
 	pkg.ABC(a, a, c) // dup name is visible
-	pkg.ABC(b, a, c) // want `passes 'b' as 'a' in call to func a/pkg.ABC\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'a' as 'b' in call to func a/pkg.ABC\(a string, b string, c string\) \(position 1 vs 0\)`
+	pkg.ABC(b, a, c) // want `passes 'b' as 'a' in call to func pkg.ABC\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'a' as 'b' in call to func pkg.ABC\(a string, b string, c string\) \(position 1 vs 0\)`
 
 	ABC(a, b, c) // good
 	ABC(a, a, c) // dup name is visible
@@ -147,15 +147,15 @@ func tests() {
 	}
 	{
 		var b, c pkg.Struct
-		TTT(b, c, c) // want `passes 'b' as 'a' in call to func TTT\[T = a/pkg.Struct\]\(a T, b T, c T\) \(position 0 vs 1\)`
+		TTT(b, c, c) // want `passes 'b' as 'a' in call to func TTT\[T = pkg.Struct\]\(a T, b T, c T\) \(position 0 vs 1\)`
 	}
 	{
 		var b, c map[pkg.Struct][]pkg.Struct
-		TTT(b, c, c) // want `passes 'b' as 'a' in call to func TTT\[T = map\[a/pkg.Struct\]\[\]a/pkg.Struct\]\(a T, b T, c T\) \(position 0 vs 1\)`
+		TTT(b, c, c) // want `passes 'b' as 'a' in call to func TTT\[T = map\[pkg.Struct\]\[\]pkg.Struct\]\(a T, b T, c T\) \(position 0 vs 1\)`
 	}
 	{
 		var b, c func(pkg.Struct) pkg.Struct
-		TTT(b, c, c) // want `passes 'b' as 'a' in call to func TTT\[T = func\(a/pkg.Struct\) a/pkg.Struct\]\(a T, b T, c T\) \(position 0 vs 1\)`
+		TTT(b, c, c) // want `passes 'b' as 'a' in call to func TTT\[T = func\(pkg.Struct\) pkg.Struct\]\(a T, b T, c T\) \(position 0 vs 1\)`
 	}
 }
 

--- a/pswap/testdata/src/a/a.go
+++ b/pswap/testdata/src/a/a.go
@@ -1,6 +1,9 @@
 package a
 
-import "a/pkg"
+import (
+	"a/pkg"
+	"slices"
+)
 
 func abc(a, b, c string) {}
 func ABC(A, B, C string) {}
@@ -129,7 +132,16 @@ func tests() {
 	i.abc(b, a, c)   // want `passes 'a' as 'b' in call to abc\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to abc\(a string, b string, c string\) \(position 0 vs 1\)`
 
 	func(c string, _ ...string) {}(a, b, c) // want `passes 'c' as '_' in call to func\(c string, _ \[\]string\) \(position 2 vs 0\)`
+
+	slices.IndexFunc(([]int)(nil), ifunc) // provokes *ast.Ident -> *types.Func in varOf (previously assumed *types.Var)
+
+	anys(pkg.ABC, con, nil) // provokes *ast.SelectorExpr -> *types.Func
+	// *ast.Ident -> *types.Const, and *ast.Ident -> *types.Nil in varOf.
 }
+
+func ifunc(int) bool { return false }
+
+const con = "constantly"
 
 type mock struct {
 	x *expectations

--- a/pswap/testdata/src/a/a.go
+++ b/pswap/testdata/src/a/a.go
@@ -92,12 +92,12 @@ func tests() {
 
 	TTT(a, b, c) // good
 	TTT(a, a, c) // dup name is visible
-	TTT(b, a, c) // want `passes 'a' as 'b' in call to func a.TTT\[T string\]\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to func a.TTT\[T string\]\(a string, b string, c string\) \(position 0 vs 1\)`
+	TTT(b, a, c) // want `passes 'a' as 'b' in call to func a.TTT\[T = string\]\(a T, b T, c T\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to func a.TTT\[T = string\]\(a T, b T, c T\) \(position 0 vs 1\)`
 
 	TUV(a, b, c) // good
 	TUV(a, a, c) // dup name is visible
 	TUV(4, a, c) // param name a mismatches type
-	TUV(b, a, c) // want `passes 'a' as 'b' in call to func a.TUV\[T string, U string, V string\]\(a string, b string, c string\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to func a.TUV\[T string, U string, V string\]\(a string, b string, c string\) \(position 0 vs 1\)`
+	TUV(b, a, c) // want `passes 'a' as 'b' in call to func a.TUV\[T = string, U = string, V = string\]\(a T, b U, c V\) \(position 1 vs 0\)` `passes 'b' as 'a' in call to func a.TUV\[T = string, U = string, V = string\]\(a T, b U, c V\) \(position 0 vs 1\)`
 
 	g := G[string]{}
 	g.abc(a, b, c) // good
@@ -143,19 +143,19 @@ func tests() {
 
 	{
 		b, c := mock{}, mock{}
-		TTT(b, c, c) // want `passes 'b' as 'a' in call to func a.TTT\[T a.mock\]\(a a.mock, b a.mock, c a.mock\) \(position 0 vs 1\)`
+		TTT(b, c, c) // want `passes 'b' as 'a' in call to func a.TTT\[T = a.mock\]\(a T, b T, c T\) \(position 0 vs 1\)`
 	}
 	{
 		var b, c pkg.Struct
-		TTT(b, c, c) // want `passes 'b' as 'a' in call to func a.TTT\[T a/pkg.Struct\]\(a a/pkg.Struct, b a/pkg.Struct, c a/pkg.Struct\) \(position 0 vs 1\)`
+		TTT(b, c, c) // want `passes 'b' as 'a' in call to func a.TTT\[T = a/pkg.Struct\]\(a T, b T, c T\) \(position 0 vs 1\)`
 	}
 	{
 		var b, c map[pkg.Struct][]pkg.Struct
-		TTT(b, c, c) // want `passes 'b' as 'a' in call to func a.TTT\[T map\[a/pkg.Struct\]\[\]a/pkg.Struct\]\(a map\[a/pkg.Struct\]\[\]a/pkg.Struct, b map\[a/pkg.Struct\]\[\]a/pkg.Struct, c map\[a/pkg.Struct\]\[\]a/pkg.Struct\) \(position 0 vs 1\)`
+		TTT(b, c, c) // want `passes 'b' as 'a' in call to func a.TTT\[T = map\[a/pkg.Struct\]\[\]a/pkg.Struct\]\(a T, b T, c T\) \(position 0 vs 1\)`
 	}
 	{
 		var b, c func(pkg.Struct) pkg.Struct
-		TTT(b, c, c) // want `passes 'b' as 'a' in call to func a.TTT\[T func\(a/pkg.Struct\) a/pkg.Struct\]\(a func\(a/pkg.Struct\) a/pkg.Struct, b func\(a/pkg.Struct\) a/pkg.Struct, c func\(a/pkg.Struct\) a/pkg.Struct\) \(position 0 vs 1\)`
+		TTT(b, c, c) // want `passes 'b' as 'a' in call to func a.TTT\[T = func\(a/pkg.Struct\) a/pkg.Struct\]\(a T, b T, c T\) \(position 0 vs 1\)`
 	}
 }
 

--- a/pswap/testdata/src/a/a.go
+++ b/pswap/testdata/src/a/a.go
@@ -137,6 +137,9 @@ func tests() {
 
 	anys(pkg.ABC, con, nil) // provokes *ast.SelectorExpr -> *types.Func
 	// *ast.Ident -> *types.Const, and *ast.Ident -> *types.Nil in varOf.
+
+	func(pro, con string) {}(con, "")   // want `passes 'con' as 'pro' in call to func\(pro string, con string\) \(position 0 vs 1\)`
+	func(abc, xyz any) {}(nil, pkg.ABC) // want `passes 'ABC' as 'xyz' in call to func\(abc any, xyz any\) \(position 1 vs 0\)`
 }
 
 func ifunc(int) bool { return false }

--- a/pswap/testdata/src/a/pkg/support.go
+++ b/pswap/testdata/src/a/pkg/support.go
@@ -1,3 +1,5 @@
 package pkg
 
 func ABC(a, b, c string) {}
+
+type Struct struct{}

--- a/pswap/testdata/src/a/ren.go
+++ b/pswap/testdata/src/a/ren.go
@@ -17,7 +17,7 @@ func rentests() {
 	// *ast.Ident -> *types.Const, and *ast.Ident -> *types.Nil in varOf.
 
 	func(pro, con string) {}(con, "")   // want `passes 'con' as 'pro' in call to func\(pro string, con string\) \(position 0 vs 1\)`
-	func(abc, xyz any) {}(nil, ren.ABC) // want `passes 'ABC' as 'xyz' in call to func\(abc any, xyz any\) \(position 1 vs 0\)`
+	func(abc, xyz any) {}(nil, ren.ABC) // want `passes 'ren\.ABC' as 'xyz' in call to func\(abc any, xyz any\) \(position 1 vs 0\)`
 }
 
 var _ = rentests

--- a/pswap/testdata/src/a/ren.go
+++ b/pswap/testdata/src/a/ren.go
@@ -1,0 +1,23 @@
+package a
+
+import (
+	ren "a/pkg"
+)
+
+// confirm that renamed imports report with renamed value
+
+func rentests() {
+	a, b, c := "a", "b", "c"
+
+	ren.ABC(a, b, c) // good
+	ren.ABC(a, a, c) // dup name is visible
+	ren.ABC(b, a, c) // want `passes 'b' as 'a' in call to func ren.ABC\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'a' as 'b' in call to func ren.ABC\(a string, b string, c string\) \(position 1 vs 0\)`
+
+	anys(ren.ABC, con, nil) // provokes *ast.SelectorExpr -> *types.Func
+	// *ast.Ident -> *types.Const, and *ast.Ident -> *types.Nil in varOf.
+
+	func(pro, con string) {}(con, "")   // want `passes 'con' as 'pro' in call to func\(pro string, con string\) \(position 0 vs 1\)`
+	func(abc, xyz any) {}(nil, ren.ABC) // want `passes 'ABC' as 'xyz' in call to func\(abc any, xyz any\) \(position 1 vs 0\)`
+}
+
+var _ = rentests

--- a/pswap/testdata/src/exact/e.go
+++ b/pswap/testdata/src/exact/e.go
@@ -8,7 +8,7 @@ func tests() {
 
 	abc(a, b, c) // good
 	abc(a, a, c) // dup name is visible
-	abc(b, a, c) // want `passes 'b' as 'a' in call to func exact.abc\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'a' as 'b' in call to func exact.abc\(a string, b string, c string\) \(position 1 vs 0\)`
+	abc(b, a, c) // want `passes 'b' as 'a' in call to func abc\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'a' as 'b' in call to func abc\(a string, b string, c string\) \(position 1 vs 0\)`
 
 	anys(c, b, a) // ignored string->any
 }

--- a/pswap/testdata/src/exact/e.go
+++ b/pswap/testdata/src/exact/e.go
@@ -8,7 +8,7 @@ func tests() {
 
 	abc(a, b, c) // good
 	abc(a, a, c) // dup name is visible
-	abc(b, a, c) // want `passes 'b' as 'a' in call to abc\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'a' as 'b' in call to abc\(a string, b string, c string\) \(position 1 vs 0\)`
+	abc(b, a, c) // want `passes 'b' as 'a' in call to func exact.abc\(a string, b string, c string\) \(position 0 vs 1\)` `passes 'a' as 'b' in call to func exact.abc\(a string, b string, c string\) \(position 1 vs 0\)`
 
 	anys(c, b, a) // ignored string->any
 }


### PR DESCRIPTION
Fix panics, handle more types, adjust messages, etc. Of note we now explain how a generic function was resolved:
  func Foo[T any](bar T)
when resolved with T=string is still evaluated as a func(bar string), but is now reported as
  func Foo[T = string](bar T)

Also package paths, when reported, are (usually) replaced with their local import names. We use a types.Qualifier instead of a string replace to omit the local package entirely and use names instead of paths.